### PR TITLE
Add func proptype for button group item

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@resmio/mantecao",
-  "version": "1.0.1-beta.2",
+  "version": "1.0.1-beta.3",
   "description": "A react UI library for resmio",
   "main": "dist/index.js",
   "scripts": {
@@ -24,6 +24,7 @@
     "ui",
     "library",
     "components",
+    "dialog",
     "resmio"
   ],
   "author": "resmio <developers@resmio.com> (https://resmio.com)",

--- a/src/components/ButtonGroup/_ButtonGroupItem.js
+++ b/src/components/ButtonGroup/_ButtonGroupItem.js
@@ -57,7 +57,7 @@ ButtonGroupItem.propTypes = {
   onSelect: func,
   selected: bool,
   text: oneOfType([string, number]),
-  value: oneOfType([string, number])
+  value: oneOfType([string, number, func])
 }
 
 export default ButtonGroupItem


### PR DESCRIPTION
fixes an error message when working in dev - a button group can also store functions as values (i.e. - for filters)